### PR TITLE
Upgrade taskcluster client for nice slugids

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "requests==2.4.3",
         "singledispatch",
         "six",
-        "taskcluster>=0.0.24",
+        "taskcluster>=0.0.26",
         "wsgiref",
     ],
     tests_require=[


### PR DESCRIPTION
This fixes e.g. this failure:

  * https://tools.taskcluster.net/task-inspector/#2AAxnGTzSeGLTX_Hwp_PVg/

due to the TaskGroupId starting with a `-`.

This is achieved by upgrading the python taskcluster client. From version 0.0.26 of python taskcluster client onwards, [_nice_ slugs](http://taskcluster.github.io/slugid.py/#usage) are returned that start with `[A-Za-f]`.

Please note this shouldn't be upgraded, until the new python client 0.0.26 has been released with https://github.com/taskcluster/taskcluster-client.py/pull/26, i.e. both the following need to exist first:

* https://pypi.python.org/pypi/taskcluster/0.0.26
* http://pypi.pub.build.mozilla.org/pub/taskcluster-0.0.26.tar.gz
