### PR TITLE
Bug 1186297, enable funsize on ash

### DIFF
--- a/funsize/worker.py
+++ b/funsize/worker.py
@@ -19,7 +19,7 @@ from funsize.utils import properties_to_dict, revision_to_revision_hash, \
 log = logging.getLogger(__name__)
 
 # TODO: move these to config
-PRODUCTION_BRANCHES = ['mozilla-central', 'mozilla-aurora']
+PRODUCTION_BRANCHES = ['mozilla-central', 'mozilla-aurora', 'ash']
 STAGING_BRANCHES = []
 PLATFORMS = ['linux', 'linux64', 'win32', 'win64', 'macosx64']
 BUILDERS = [


### PR DESCRIPTION
Adds ash to production. We're only doing en-US builds for desktop, so load should be minimal.